### PR TITLE
Handle pebble ready event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.idea
 /target
 *.charm

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 /target
 *.charm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,9 @@ where
                 "start" => Event::Start,
                 "stop" => Event::Stop,
                 name => {
-                    if let Some(prefix) = name.strip_suffix("-relation-joined") {
+                    if let Some(prefix) = name.strip_suffix("-pebble-ready") {
+                        Event::PebbleReady(prefix.to_owned())
+                    } else if let Some(prefix) = name.strip_suffix("-relation-joined") {
                         Event::RelationJoined(prefix.to_owned())
                     } else if let Some(prefix) = name.strip_suffix("-relation-broken") {
                         Event::RelationBroken(prefix.to_owned())


### PR DESCRIPTION
First of all, thanks for the amazing framework implementation, @samuelallan72!

I managed to start developing a small K8s operator to deploy [Qdrant](https://github.com/qdrant/qdrant). It's available at https://github.com/marceloneppel/qdrant-k8s-operator.

Now, talking about this PR, I updated the framework code to handle the pebble ready event.